### PR TITLE
fixing diamonds

### DIFF
--- a/src/main/java/gameframework/drawing/DrawableComposite.java
+++ b/src/main/java/gameframework/drawing/DrawableComposite.java
@@ -4,7 +4,7 @@ import java.awt.Graphics;
 import java.util.Vector;
 
 public class DrawableComposite implements Drawable {
-	protected Vector<Drawable> drawables = new Vector<Drawable>();
+	protected Vector<Drawable> drawables = new Vector<>();
 
 	public void add(Drawable e) {
 		drawables.addElement(e);

--- a/src/main/java/gameframework/drawing/SpriteManagerDefaultImpl.java
+++ b/src/main/java/gameframework/drawing/SpriteManagerDefaultImpl.java
@@ -31,7 +31,7 @@ public class SpriteManagerDefaultImpl implements SpriteManager {
 	@Override
 	public void setTypes(String... types) {
 		int i = 0;
-		this.types = new HashMap<String, Integer>(types.length);
+		this.types = new HashMap<>(types.length);
 		for (String type : types) {
 			this.types.put(type, i);
 			i++;

--- a/src/main/java/gameframework/game/GameData.java
+++ b/src/main/java/gameframework/game/GameData.java
@@ -28,10 +28,10 @@ public class GameData {
 		this.configuration = configuration;
 
 		canvas = configuration.createCanvas();
-		score = new ObservableValue<Integer>(0);
-		life = new ObservableValue<Integer>(configuration.getDefaultNbLives());
-		endOfGame = new ObservableValue<Boolean>(false);
-		levels = new ArrayList<GameLevel>();
+		score = new ObservableValue<>(0);
+		life = new ObservableValue<>(configuration.getDefaultNbLives());
+		endOfGame = new ObservableValue<>(false);
+		levels = new ArrayList<>();
 
 		universe = configuration.createUniverse(this);
 

--- a/src/main/java/gameframework/game/GameUniverseDefaultImpl.java
+++ b/src/main/java/gameframework/game/GameUniverseDefaultImpl.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class GameUniverseDefaultImpl implements GameUniverse {
-	protected ConcurrentLinkedQueue<GameEntity> gameEntities = new ConcurrentLinkedQueue<GameEntity>();
+	protected ConcurrentLinkedQueue<GameEntity> gameEntities = new ConcurrentLinkedQueue<>();
 	protected final GameData data;
 
 	

--- a/src/main/java/gameframework/gui/GameStatusBar.java
+++ b/src/main/java/gameframework/gui/GameStatusBar.java
@@ -10,7 +10,7 @@ import javax.swing.JPanel;
 
 public class GameStatusBar implements Observer {
 
-	protected final ArrayList<GameStatusBarElement<?>> elements = new ArrayList<GameStatusBarElement<?>>();
+	protected final ArrayList<GameStatusBarElement<?>> elements = new ArrayList<>();
 
 	public Container getContainer() {
 		JPanel container = new JPanel();

--- a/src/main/java/gameframework/motion/MoveStrategyConfigurableKeyboard.java
+++ b/src/main/java/gameframework/motion/MoveStrategyConfigurableKeyboard.java
@@ -66,8 +66,8 @@ public class MoveStrategyConfigurableKeyboard extends KeyAdapter implements Move
 	public MoveStrategyConfigurableKeyboard(Boolean alwaysMove, SpeedVector speedVector, Boolean combineDirections) {
 		this.alwaysMove = alwaysMove;
 		this.speedVector = speedVector;
-		this.directions = new HashMap<Integer, Point>();
-		this.keyPressed = new HashSet<Integer>();
+		this.directions = new HashMap<>();
+		this.keyPressed = new HashSet<>();
 		this.combineDirections = combineDirections;
 	}
 	

--- a/src/main/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImpl.java
+++ b/src/main/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImpl.java
@@ -27,7 +27,7 @@ public class MoveBlockerCheckerDefaultImpl implements MoveBlockerChecker {
 	protected MoveBlockerRulesApplier moveBlockerRuleApplier;
 
 	public MoveBlockerCheckerDefaultImpl() {
-		moveBlockers = new ConcurrentLinkedQueue<MoveBlocker>();
+		moveBlockers = new ConcurrentLinkedQueue<>();
 		this.moveBlockerRuleApplier = new MoveBlockerRulesApplierDefaultImpl();
 	}
 
@@ -61,7 +61,7 @@ public class MoveBlockerCheckerDefaultImpl implements MoveBlockerChecker {
 	@Override
 	public boolean moveValidation(GameMovable m, SpeedVector mov) {
 		Shape intersectShape = IntersectTools.getIntersectShape(m, mov);
-		Vector<MoveBlocker> moveBlockersInIntersection = new Vector<MoveBlocker>();
+		Vector<MoveBlocker> moveBlockersInIntersection = new Vector<>();
 		Area intersectArea = new Area(intersectShape);
 		Rectangle tmpIntersec = (intersectShape.getBounds());
 

--- a/src/main/java/gameframework/motion/overlapping/Overlap.java
+++ b/src/main/java/gameframework/motion/overlapping/Overlap.java
@@ -23,8 +23,8 @@ public class Overlap {
 	}
 
 	public Set<Overlappable> getOverlappables() {
-		return new HashSet<Overlappable>(Arrays.asList(overlappable1,
-				overlappable2));
+		return new HashSet<>(Arrays.asList(overlappable1,
+                overlappable2));
 	}
 
 }

--- a/src/main/java/gameframework/motion/overlapping/OverlapProcessorDefaultImpl.java
+++ b/src/main/java/gameframework/motion/overlapping/OverlapProcessorDefaultImpl.java
@@ -24,8 +24,8 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 	protected OverlapRulesApplier overlapRules;
 
 	public OverlapProcessorDefaultImpl() {
-		nonMovableOverlappables = new ConcurrentLinkedQueue<Overlappable>();
-		movableOverlappables = new ConcurrentLinkedQueue<Overlappable>();
+		nonMovableOverlappables = new ConcurrentLinkedQueue<>();
+		movableOverlappables = new ConcurrentLinkedQueue<>();
 	}
 
 	@Override
@@ -56,8 +56,8 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 
 	@Override
 	public void processOverlapsAll() {
-		Vector<Overlap> overlaps = new Vector<Overlap>();
-		movablesTmp = new Vector<Overlappable>(movableOverlappables);
+		Vector<Overlap> overlaps = new Vector<>();
+		movablesTmp = new Vector<>(movableOverlappables);
 		for (Overlappable movableOverlappable : movableOverlappables) {
 			movablesTmp.remove(movableOverlappable);
 			computeOneOverlap(movableOverlappable, overlaps);


### PR DESCRIPTION
##### Opendev - Team n°2
-----

Java 7 introduced the diamond operator (<>) to reduce the verbosity of generics code. For instance, instead of having to declare a List's type in both its declaration and its constructor, you can now simplify the constructor declaration with <>, and the compiler will infer the type. Doing so will increase code readability.

Noncompliant Code Example

```java
List<String> strings = new ArrayList<String>();  // Noncompliant
Map<String,List<Integer>> map = new HashMap<String,List<Integer>>();  // Noncompliant
```

Compliant Solution
```java
List<String> strings = new ArrayList<>();
Map<String,List<Integer>> map = new HashMap<>();
```

