### PR TITLE
Replace old synchronized classes with modern ones

### DIFF
--- a/src/main/java/gameframework/drawing/DrawableComposite.java
+++ b/src/main/java/gameframework/drawing/DrawableComposite.java
@@ -1,17 +1,18 @@
 package gameframework.drawing;
 
-import java.awt.Graphics;
-import java.util.Vector;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DrawableComposite implements Drawable {
-	protected Vector<Drawable> drawables = new Vector<>();
+	protected List<Drawable> drawables = new ArrayList<>();
 
 	public void add(Drawable e) {
-		drawables.addElement(e);
+		drawables.add(e);
 	}
 
 	public void remove(Drawable e) {
-		drawables.removeElement(e);
+		drawables.remove(e);
 	}
 
 	@Override

--- a/src/main/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImpl.java
+++ b/src/main/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImpl.java
@@ -1,13 +1,13 @@
 package gameframework.motion.blocking;
 
-import gameframework.motion.IntersectTools;
 import gameframework.motion.GameMovable;
+import gameframework.motion.IntersectTools;
 import gameframework.motion.SpeedVector;
 
-import java.awt.Rectangle;
-import java.awt.Shape;
+import java.awt.*;
 import java.awt.geom.Area;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -61,7 +61,7 @@ public class MoveBlockerCheckerDefaultImpl implements MoveBlockerChecker {
 	@Override
 	public boolean moveValidation(GameMovable m, SpeedVector mov) {
 		Shape intersectShape = IntersectTools.getIntersectShape(m, mov);
-		Vector<MoveBlocker> moveBlockersInIntersection = new Vector<>();
+		List<MoveBlocker> moveBlockersInIntersection = new ArrayList<>();
 		Area intersectArea = new Area(intersectShape);
 		Rectangle tmpIntersec = (intersectShape.getBounds());
 

--- a/src/main/java/gameframework/motion/blocking/MoveBlockerRulesApplier.java
+++ b/src/main/java/gameframework/motion/blocking/MoveBlockerRulesApplier.java
@@ -3,7 +3,7 @@ package gameframework.motion.blocking;
 import gameframework.game.GameData;
 import gameframework.motion.GameMovable;
 
-import java.util.Vector;
+import java.util.List;
 
 /**
  *  The classes implementing this interface are used to apply movement rules
@@ -23,7 +23,7 @@ public interface MoveBlockerRulesApplier {
 	 * @param obs the MoveBlocker vector
 	 * @return true if the movable is allowed to move, false otherwise
 	 */
-	public boolean moveValidationProcessing(GameMovable m, Vector<MoveBlocker> obs);
+	public boolean moveValidationProcessing(GameMovable m, List<MoveBlocker> obs);
 
 	public void setGameData(GameData gameData);
 }

--- a/src/main/java/gameframework/motion/blocking/MoveBlockerRulesApplierDefaultImpl.java
+++ b/src/main/java/gameframework/motion/blocking/MoveBlockerRulesApplierDefaultImpl.java
@@ -5,7 +5,7 @@ import gameframework.motion.GameMovable;
 import gameframework.motion.IllegalMoveException;
 
 import java.lang.reflect.Method;
-import java.util.Vector;
+import java.util.List;
 
 /**
  * Take care of special blocking rules for your game. By default, a
@@ -38,10 +38,10 @@ public class MoveBlockerRulesApplierDefaultImpl implements
 	protected GameData gameData;
 
 	/**
-	 * @see gameframework.motion.blocking.MoveBlockerRulesApplier#moveValidationProcessing(gameframework.motion.GameMovable, java.util.Vector)
+	 * @see gameframework.motion.blocking.MoveBlockerRulesApplier#moveValidationProcessing(gameframework.motion.GameMovable, java.util.List)
 	 */
 	@Override
-	public boolean moveValidationProcessing(GameMovable movable, Vector<MoveBlocker> blockers) {
+	public boolean moveValidationProcessing(GameMovable movable, List<MoveBlocker> blockers) {
 		for (MoveBlocker moveBlocker : blockers) {
 			try {
 				moveBlockerRuleApply(movable, moveBlocker);

--- a/src/main/java/gameframework/motion/overlapping/OverlapProcessorDefaultImpl.java
+++ b/src/main/java/gameframework/motion/overlapping/OverlapProcessorDefaultImpl.java
@@ -7,8 +7,8 @@ import gameframework.motion.GameMovable;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Area;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class OverlapProcessorDefaultImpl implements OverlapProcessor {
@@ -56,8 +56,8 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 
 	@Override
 	public void processOverlapsAll() {
-		Vector<Overlap> overlaps = new Vector<>();
-		movablesTmp = new Vector<>(movableOverlappables);
+		List<Overlap> overlaps = new ArrayList<>();
+		movablesTmp = new ArrayList<>(movableOverlappables);
 		for (Overlappable movableOverlappable : movableOverlappables) {
 			movablesTmp.remove(movableOverlappable);
 			computeOneOverlap(movableOverlappable, overlaps);
@@ -66,7 +66,7 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 	}
 
 	protected void computeOneOverlap(Overlappable movableOverlappable,
-			Vector<Overlap> overlaps) {
+			List<Overlap> overlaps) {
 		Area overlappableArea;
 		Rectangle boundingBoxOverlappable;
 		assert movableOverlappable.isMovable();
@@ -83,7 +83,7 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 	}
 
 	protected void computeOneOverlapMovables(Overlappable movableOverlappable,
-			Vector<Overlap> overlaps, Rectangle boundingBoxOverlappable,
+			List<Overlap> overlaps, Rectangle boundingBoxOverlappable,
 			Area overlappableArea){
 
 		Rectangle boundingBoxTarget;
@@ -104,7 +104,7 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 	}
 
 	protected void computeOneOverlapNonMovableOverlappables(Overlappable movableOverlappable,
-			Vector<Overlap> overlaps, Rectangle boundingBoxOverlappable,
+			List<Overlap> overlaps, Rectangle boundingBoxOverlappable,
 			Area overlappableArea){
 		Rectangle boundingBoxTarget;
 		for (Overlappable targetNonMovableOverlappable : nonMovableOverlappables) {
@@ -121,7 +121,7 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 	}
 
 	protected void addOverlapsIfIntersect(Rectangle boundingBoxOverlappable, Rectangle boundingBoxTarget,
-			Shape targetShape, Area overlappableArea, Vector<Overlap> overlaps,
+			Shape targetShape, Area overlappableArea, List<Overlap> overlaps,
 			Overlappable movableOverlappable, Overlappable targetOverlappable){
 		if (boundingBoxOverlappable.intersects(boundingBoxTarget)) {
 			Area targetArea = new Area(targetShape);

--- a/src/main/java/gameframework/motion/overlapping/OverlapRulesApplier.java
+++ b/src/main/java/gameframework/motion/overlapping/OverlapRulesApplier.java
@@ -2,12 +2,12 @@ package gameframework.motion.overlapping;
 
 import gameframework.game.GameData;
 
-import java.util.Vector;
+import java.util.List;
 
 public interface OverlapRulesApplier {
 	public void setGameData(GameData data);
 	/**
 	 * Modify the Universe depending on all the overlaps in parameter.
 	 */
-	public void applyOverlapRules(Vector<Overlap> overlaps);
+	public void applyOverlapRules(List<Overlap> overlaps);
 }

--- a/src/main/java/gameframework/motion/overlapping/OverlapRulesApplierDefaultImpl.java
+++ b/src/main/java/gameframework/motion/overlapping/OverlapRulesApplierDefaultImpl.java
@@ -4,14 +4,15 @@ import gameframework.game.GameData;
 import gameframework.game.GameUniverse;
 
 import java.lang.reflect.Method;
-import java.util.Vector;
+import java.util.List;
+
 
 public class OverlapRulesApplierDefaultImpl implements OverlapRulesApplier {
 
 	protected GameData data;
 	
 	@Override
-	public void applyOverlapRules(Vector<Overlap> overlaps) {
+	public void applyOverlapRules(List<Overlap> overlaps) {
 		for (Overlap col : overlaps) {
 			applySpecificOverlapRule(col.getOverlappable1(), col.getOverlappable2(),
 					true);

--- a/src/test/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImplTest.java
+++ b/src/test/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImplTest.java
@@ -3,19 +3,16 @@ package gameframework.motion.blocking;
 import gameframework.game.GameData;
 import gameframework.motion.GameMovable;
 import gameframework.motion.SpeedVector;
-
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Vector;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class MoveBlockerCheckerDefaultImplTest {
 
@@ -24,7 +21,7 @@ public class MoveBlockerCheckerDefaultImplTest {
 	GameMovable movable;
 	int width = 100;
 	int height = 200;
-	Vector<MoveBlocker> foundBlockers = new Vector<MoveBlocker>();
+	List<MoveBlocker> foundBlockers = new ArrayList<MoveBlocker>();
 
 	@Before
 	public void createMovable() {
@@ -48,7 +45,7 @@ public class MoveBlockerCheckerDefaultImplTest {
 
 			@Override
 			public boolean moveValidationProcessing(GameMovable m,
-					Vector<MoveBlocker> blockers) {
+					List<MoveBlocker> blockers) {
 				foundBlockers = blockers;
 				// by default, a blocker invalidates the move
 				return false;

--- a/src/test/java/gameframework/motion/blocking/MoveBlockerRulesApplierDefaultImplTest.java
+++ b/src/test/java/gameframework/motion/blocking/MoveBlockerRulesApplierDefaultImplTest.java
@@ -2,20 +2,18 @@ package gameframework.motion.blocking;
 
 import gameframework.motion.GameMovable;
 import gameframework.motion.IllegalMoveException;
-
-import java.awt.Rectangle;
-import java.util.Vector;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class MoveBlockerRulesApplierDefaultImplTest {
 
-	Vector<MoveBlocker> moveBlockers = new Vector<MoveBlocker>();
+	List<MoveBlocker> moveBlockers = new ArrayList<MoveBlocker>();
 	MyMovable movable = new MyMovable();
 	int rulesApplied = 0;
 	MoveBlockerRulesApplier rulesApplier;

--- a/src/test/java/gameframework/motion/overlapping/OverlapProcessorDefaultImplTest.java
+++ b/src/test/java/gameframework/motion/overlapping/OverlapProcessorDefaultImplTest.java
@@ -2,24 +2,19 @@ package gameframework.motion.overlapping;
 
 import gameframework.game.GameData;
 import gameframework.motion.GameMovable;
-
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Vector;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import java.awt.*;
+import java.util.*;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class OverlapProcessorDefaultImplTest {
 
 	OverlapProcessorDefaultImpl overlapProcessor;
-	Vector<Overlap> actualOverlaps;
+	List<Overlap> actualOverlaps;
 
 	@Before
 	public void createOverlapProcessor() {
@@ -27,7 +22,7 @@ public class OverlapProcessorDefaultImplTest {
 		overlapProcessor.setOverlapRules(new OverlapRulesApplier() {
 
 			@Override
-			public void applyOverlapRules(Vector<Overlap> overlaps) {
+			public void applyOverlapRules(List<Overlap> overlaps) {
 				actualOverlaps = overlaps;
 			}
 

--- a/src/test/java/gameframework/motion/overlapping/OverlapRulesApplierDefaultImplTest.java
+++ b/src/test/java/gameframework/motion/overlapping/OverlapRulesApplierDefaultImplTest.java
@@ -1,17 +1,14 @@
 package gameframework.motion.overlapping;
 
-import java.util.Arrays;
-import java.util.Vector;
-
+import gameframework.motion.overlapping.mocks.OverlappableMock;
+import gameframework.motion.overlapping.mocks.OverlappableMovableMock;
 import org.junit.Before;
 import org.junit.Test;
 
-import gameframework.motion.overlapping.mocks.OverlappableMock;
-import gameframework.motion.overlapping.mocks.OverlappableMovableMock;
+import java.util.ArrayList;
+import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class OverlapRulesApplierDefaultImplTest {
 
@@ -46,7 +43,7 @@ public class OverlapRulesApplierDefaultImplTest {
 	@Test
 	public void testApplyRuleInCorrectOrder() {
 		ruleApplier.applyOverlapRules(
-			new Vector<Overlap>(Arrays.asList(
+				new ArrayList<>(Collections.singletonList(
 					new Overlap(overlappable, overlappableMovable)
 				)));
 		assertEquals(1, rulesApplied);
@@ -55,8 +52,8 @@ public class OverlapRulesApplierDefaultImplTest {
 	@Test
 	public void testApplyRuleInReverseOrder() {
 		ruleApplier.applyOverlapRules(
-			new Vector<Overlap>(Arrays.asList(
-					new Overlap(overlappableMovable, overlappable)
+				new ArrayList<>(Collections.singletonList(
+						new Overlap(overlappableMovable, overlappable)
 				)));
 		assertEquals(1, rulesApplied);
 	}
@@ -64,7 +61,7 @@ public class OverlapRulesApplierDefaultImplTest {
 	@Test
 	public void testApplyNonExistingRule() {
 		ruleApplier.applyOverlapRules(
-			new Vector<Overlap>(Arrays.asList(
+				new ArrayList<>(Collections.singletonList(
 					new Overlap(overlappable, overlappable)
 				)));
 		assertEquals(0, rulesApplied);
@@ -75,7 +72,7 @@ public class OverlapRulesApplierDefaultImplTest {
 		ruleShouldCrash = true;
 		try {
 			ruleApplier.applyOverlapRules(
-				new Vector<Overlap>(Arrays.asList(
+					new ArrayList<>(Collections.singletonList(
 						new Overlap(overlappable, overlappableMovable)
 					)));
 			fail("Previous instruction should have crashed");


### PR DESCRIPTION
##### Opendev - Team n°2
-----

Early classes of the Java API, such as `Vector`, `Hashtable` and `StringBuffer`, were synchronized to make them thread-safe. Unfortunately, synchronization has a big negative impact on performance, even when using these collections from a single thread.

It is better to use their new unsynchronized replacements:

`ArrayList` or `LinkedList` instead of `Vector`

`Deque` instead of `Stack`

`HashMap` instead of `Hashtable`

`StringBuilder` instead of `StringBuffer`



##### Noncompliant Code Example
```java
Vector cats = new Vector(); 
```

##### Compliant Solution

```java
ArrayList cats = new ArrayList(); 
```

##### Exceptions

Use of those synchronized classes is allowed in method signatures when overriding an existing method.
```java
@Override
public Vector getCats() {...} 
```