### PR TITLE
Add getCellPositionByIndex in GameLevelDefaultImpl

### DIFF
--- a/src/main/java/gameframework/game/GameLevelDefaultImpl.java
+++ b/src/main/java/gameframework/game/GameLevelDefaultImpl.java
@@ -29,6 +29,17 @@ public abstract class GameLevelDefaultImpl extends Thread implements GameLevel {
 		this.minimumDelayBetweenCycles = minimumDelayBetweenCycles;
 	}
 
+	/**
+	 * Returns the position of a cell by it's index.
+	 * This is very useful for a game that relies on cells, the size of those cells are determined by the size of the
+	 * sprites (which is defined by the game configuration your game is using).
+	 * @param i The index of the cell you wish to retrieve it's position.
+	 * @return The position of the cell.
+	 */
+	public int getCellPositionByIndex(int i) {
+		return i * this.spriteSize;
+	}
+
 	@Override
 	public void start() {
 		init();


### PR DESCRIPTION
##### Opendev - Team n°3
-----

This pull request add a new method called `getCellPositionByIndex(int i)` for the `GameLevelDefaultImpl` class.

This method is very useful for games that relies on cells (also called tiles), let's take this example (thanks [GamyGuru](https://gamyguru.wordpress.com/2012/07/29/inside-the-game-tile-based-game-architecture/) for the image):

![Super Mario Bros](https://gamyguru.files.wordpress.com/2012/07/free-download-pc-mini-games-super-mario-bros-full-rip-version-classic-game-gratis.jpg?w=604)

In the above screenshot, the level is using a 10x8 cells configuration. Assuming I'm designing the level and positionning the mystery box on the left (the one located at X = 1 and Y = 3), I could just do something like this:

```java
int boxX = this.getCellByIndex(1); // Instead of 1 * this.spriteSize;
int boxY = this.getCellByIndex(3); // Instead of 3 * this.spriteSize;
this.universe.addGameEntity(new MysteryBox(boxX, boxY));
```

The result from `getCellByIndex` depends on the size of the sprite defined in the game's configuration (the `GameConfiguration` class).