### PR TITLE
Allow custom GameMenuBar to be used within GameWindow

### DIFF
--- a/src/main/java/gameframework/gui/GameWindow.java
+++ b/src/main/java/gameframework/gui/GameWindow.java
@@ -15,19 +15,28 @@ public class GameWindow {
 
 	protected final Frame frame;
 	protected GameCanvas gameCanvas;
-	protected final GameStatusBar statusBar = new GameStatusBar();
+	protected GameStatusBar statusBar = new GameStatusBar();
 	
 	public GameWindow(String gameName, GameCanvas gameCanvas, GameData data) {
-		this(gameName, gameCanvas, data.getConfiguration(),
+		this(gameName, gameCanvas, data.getConfiguration(), new GameStatusBar(),
+				new GameStatusBarElement<>("Score:", data.getScore()),
+				new GameStatusBarElement<>("Life:", data.getLife()));
+	}
+
+	public GameWindow(String gameName, GameCanvas gameCanvas, GameData data, GameStatusBar statusBar) {
+		this(gameName, gameCanvas, data.getConfiguration(), statusBar,
 				new GameStatusBarElement<>("Score:", data.getScore()),
 				new GameStatusBarElement<>("Life:", data.getLife()));
 	}
 
 	public GameWindow(String gameName, GameCanvas gameCanvas,
-			GameConfiguration configuration,
+			GameConfiguration configuration, GameStatusBar statusBar,
 			GameStatusBarElement<?>... elementsStatusBar) {
 		if (gameCanvas == null) {
 			throw new IllegalArgumentException("gameCanvas is null");
+		}
+		if (statusBar == null) {
+			this.statusBar = new GameStatusBar();
 		}
 		this.statusBar.addAll(elementsStatusBar);
 		this.frame = new Frame(gameName);


### PR DESCRIPTION
##### Opendev - Team n°3
-----

This PR allow developers to use their own "version" of `GameMenuBar` in the `GameWindow` class providing them more control over customization.

In order to customize our game status bar for the game made by my team and myself, we were "forced" to have our own version of `GameWindow`. Even if we did changed the `statusBar` variable to our instanciate our own version of `GameStatusBar`, the framework was still using the default `GameStatusBar` for an unknown reason. In other words, we had to remove the `extends GameWindow` line from our version of `GameWindow` and copy/paste it's code.